### PR TITLE
async option, return error instead of option

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ Mail.basicDashboard = {
     name: 'secret',
     type: 'text',
     description: 'secret key or password to make external requests, only for external calls, will be ignored for internal calls'
-  }]
+  }, {
+      name: 'async',
+      type: 'checkbox',
+      description: 'make the email request asynchronous'
+    }]
 };
 
 
@@ -99,7 +103,6 @@ Mail.prototype.handle = function(ctx, next) { //Comportamiento al llamar funcion
       });
     }
   }
-
 
 
   var options = ctx.body;
@@ -133,13 +136,19 @@ Mail.prototype.handle = function(ctx, next) { //Comportamiento al llamar funcion
     options,
     function(err, response) {
       if (err) {
-        return ctx.done(options.html);
+        console.log(err)
+        return ctx.done(err);
       }
       ctx.done(null, {
         message: response.message
       });
     }
   );
- 
+  
+  if(this.config.async) {
+    ctx.done(null, {
+      message: 'email is queued for sending'
+    });
+  }
 
 }


### PR DESCRIPTION
Added : async option in config
Usage : when you need to call dpd.mail inside other event and need an async option. 

---
[UPDATE] return error instead of options.html
[ADD] async option